### PR TITLE
Set default platform target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"


### PR DESCRIPTION
- stops rust-analyzer from displaying errors
- makes setting up build tasks easier