### PR TITLE
do not unwrap without providing another value

### DIFF
--- a/src/renderer/webgl2_render_resource_context.rs
+++ b/src/renderer/webgl2_render_resource_context.rs
@@ -548,7 +548,7 @@ impl RenderResourceContext for WebGL2RenderResourceContext {
     }
     fn get_specialized_shader(&self, shader: &Shader, macros: Option<&[String]>) -> Shader {
         if let ShaderSource::Glsl(source) = &shader.source {
-            let source = (&source).strip_prefix('\n').unwrap();
+            let source = (&source).strip_prefix('\n').unwrap_or(source);
             assert!(source.starts_with("#version"));
             let eol_index = source.find('\n').unwrap();
             let (version_str, source) = source.split_at(eol_index);


### PR DESCRIPTION
fixes #8 

from the [doc of `strip_prefix`](https://doc.rust-lang.org/std/string/struct.String.html#method.strip_prefix), it returns `None` if nothing was stripped.

provide the actual value if it wasn't stripped

`trim_start_matches` could also be used instead of `strip_prefix` as it doesn't return an `Option` but they differ on one other point:
- `strip_prefix` will remove the prefix only once
- `trim_start_matches` will remove it as long as it matches