### PR TITLE
Exclude extraneous files from packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "bevy_webgl2"
 version = "0.4.0"
 repository = "https://github.com/mrk-its/bevy_webgl2"
 readme = "README.md"
+exclude = ["assets/**/*", ".github/**/*", "index.html", "fix_bevy_example.sh", "Makefile.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I've just noticed that bevy_webgl2 size on crates.io is 6.57MB. I think the most contributing factor is the asset folder. I added the `exclude` field to `Cargo.toml`, which also specifies some other files that, I believe, are not needed for the crates.io package.