### PR TITLE
Disable scissor test at the beginning of a render pass

### DIFF
--- a/src/renderer/webgl2_render_context.rs
+++ b/src/renderer/webgl2_render_context.rs
@@ -150,6 +150,7 @@ impl RenderContext for WebGL2RenderContext {
     ) {
         let mut clear_mask = 0;
         let gl = &self.device.get_context();
+        gl_call!(gl.disable(Gl::SCISSOR_TEST));
 
         if let LoadOp::Clear(c) = pass_descriptor.color_attachments[0].ops.load {
             gl_call!(gl.clear_color(c.r(), c.g(), c.b(), c.a()));


### PR DESCRIPTION
I've stumbled upon an edge case when having a scissor state from the previous render pass prevented buffers from being cleared.
Disabling scissors at the beginning of a render pass seems to fix it.