### PR TITLE
Fix double binding

### DIFF
--- a/src/renderer/utils.rs
+++ b/src/renderer/utils.rs
@@ -153,6 +153,8 @@ pub fn reflect_layout(context: &WebGl2RenderingContext, program: &GlProgram) -> 
         index
     }
 
+    let mut names: Vec<String> = Vec::with_capacity(active_uniform_blocks as usize);
+
     for uniform_index in 0..active_uniform_blocks {
         let name = gl
             .get_active_uniform_block_name(&program.program, uniform_index)
@@ -176,9 +178,7 @@ pub fn reflect_layout(context: &WebGl2RenderingContext, program: &GlProgram) -> 
 
                 bind_groups.push(BindGroupDescriptor::new(0, vec![camera_position]));
             }
-            continue;
-        }
-        if name == "CameraViewProj" {
+        } else if name == "CameraViewProj" {
             let camera_descriptor = BindingDescriptor {
                 name: "CameraViewProj".to_string(),
                 index: 0,
@@ -196,15 +196,13 @@ pub fn reflect_layout(context: &WebGl2RenderingContext, program: &GlProgram) -> 
 
                 bind_groups.push(BindGroupDescriptor::new(0, vec![camera_descriptor]));
             }
-
-            continue;
         }
+
+        names.push(name);
     }
 
     for uniform_index in 0..active_uniform_blocks {
-        let name = gl
-            .get_active_uniform_block_name(&program.program, uniform_index)
-            .unwrap();
+        let name = &names[uniform_index as usize];
 
         if name == "CameraPosition" || name == "CameraViewProj" {
             continue;
@@ -244,15 +242,15 @@ pub fn reflect_layout(context: &WebGl2RenderingContext, program: &GlProgram) -> 
         //     active_uniforms,
         //     active_uniform_indices
         // );
-        let (group_index, index) =
-            if let Some((group_index, index)) = program.bind_groups.get(&name) {
-                (*group_index, *index)
-            } else {
-                (next_group_index(&mut used_indices), 0)
-            };
+        let (group_index, index) = if let Some((group_index, index)) = program.bind_groups.get(name)
+        {
+            (*group_index, *index)
+        } else {
+            (next_group_index(&mut used_indices), 0)
+        };
         let property = UniformProperty::Array(Box::new(UniformProperty::UInt), size as usize / 4);
         let binding = BindingDescriptor {
-            name,
+            name: name.to_string(),
             index,
             bind_type: BindType::Uniform {
                 has_dynamic_offset: false,

--- a/src/renderer/utils.rs
+++ b/src/renderer/utils.rs
@@ -199,6 +199,16 @@ pub fn reflect_layout(context: &WebGl2RenderingContext, program: &GlProgram) -> 
 
             continue;
         }
+    }
+
+    for uniform_index in 0..active_uniform_blocks {
+        let name = gl
+            .get_active_uniform_block_name(&program.program, uniform_index)
+            .unwrap();
+
+        if name == "CameraPosition" || name == "CameraViewProj" {
+            continue;
+        }
 
         let size = gl
             .get_active_uniform_block_parameter(


### PR DESCRIPTION
Although I'm still not completely sure about the mechanism by which this occurs, I have been seeing an issue with projects using bevy_webgl2 and custom pipelines specifically in Chrome (stable, beta, and canary) on macOS 11.2.3 (intel, radeon).

https://github.com/vleue/bevy_zhuose_qi (the fire shader specifically)
https://github.com/Nilirad/bevy_prototype_lyon/

Are affected, but bevy itself seems to generally work fine.

It seems that the CameraViewProj and and (any other uniform) both end up bound to (0, 0). This is resulting in a "grey screen, no errors" situation.

This change set fixes the issue in both projects for me.