### PR TITLE
Bump winit to v0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = [
 ]
 
 [dependencies]
-winit = {version = "0.24.0", features = ["web-sys"]}
+winit = {version = "0.25.0", features = ["web-sys"]}
 bevy = { version="0.5.0", default-features=false }
 
 regex = "1.4"


### PR DESCRIPTION
winit v0.25 includes support for propagating mouse motion events in the HTML canvas to the winit window.

I've submitted a similar patch to bevy_winit. The versions will be out of sync, if both repositories don't update before the next release.