### PR TITLE
Fix building with latest Bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,6 @@ web-sys = {version = "0.3.50", features = [
   'WebGlSync',
 ]}
 
-[patch.crates-io]
-# bevy = {path = "../bevy", default-features=false}
-bevy = {git = "https://github.com/bevyengine/bevy", branch="main", default-features=false}
-
 [dev-dependencies]
 compile-time-run = "0.2"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ default = [
 winit = {version = "0.25.0", features = ["web-sys"]}
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features=false }
 
-regex = "1.4"
+regex = "1.5"
 cfg-if = "1.0.0"
-js-sys = "0.3.50"
-parking_lot = "0.11.0"
-wasm-bindgen = "0.2.73"
+js-sys = "0.3.53"
+parking_lot = "0.11.1"
+wasm-bindgen = "0.2.76"
 web-sys = {version = "0.3.50", features = [
   'Document',
   'Element',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = [
 
 [dependencies]
 winit = {version = "0.25.0", features = ["web-sys"]}
-bevy = { git = "https://github.com/bevyengine/bevy", default-features=false }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features=false }
 
 regex = "1.4"
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = [
 
 [dependencies]
 winit = {version = "0.25.0", features = ["web-sys"]}
-bevy = { version="0.5.0", default-features=false }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features=false }
 
 regex = "1.4"
 cfg-if = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,9 @@ pub enum WebGL2Stage {
 pub struct WebGL2Plugin;
 
 impl Plugin for WebGL2Plugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         {
-            let world = app.world_mut();
+            let world = &mut app.world;
             let cell = world.cell();
             let pipelines = cell
                 .get_resource_mut::<Assets<PipelineDescriptor>>()
@@ -94,7 +94,7 @@ impl Plugin for WebGL2Plugin {
                 }
             }
         }
-        let world = app.world_mut();
+        let world = &mut app.world;
         let render_system = webgl2_render_system(world);
         let handle_events_system = webgl2_handle_window_created_events_system();
         app.add_stage_before(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use bevy::render::{
     shader::{Shader, ShaderStage},
     RenderStage,
 };
+use bevy::prelude::Plugin;
 
 pub const SPRITE_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 2785347840338765446);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub enum WebGL2Stage {
 #[derive(Default)]
 pub struct WebGL2Plugin;
 
-impl Plugin for WebGL2Plugin {
+impl bevy::prelude::Plugin for WebGL2Plugin {
     fn build(&self, app: &mut App) {
         {
             let world = &mut app.world;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ use bevy::render::{
     shader::{Shader, ShaderStage},
     RenderStage,
 };
-use bevy::prelude::Plugin;
 
 pub const SPRITE_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 2785347840338765446);


### PR DESCRIPTION
I just made some slight modifications to the library so that it would build on the latest Bevy git commit (and so the code will be more prepared for v0.6).