### PR TITLE
Remove explicit 'main' branch from bevy dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = [
 
 [dependencies]
 winit = {version = "0.25", features = ["web-sys"]}
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features=false }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features=false }
 
 regex = "1.5"
 cfg-if = "1.0"


### PR DESCRIPTION
`main` is the default branch, and using it explicitly in the dependency makes for confusing missing trait implementation errors if it's not propagated to every other bevy git dependency, since explicit and implicit default branches are resolved to different dependency versions.